### PR TITLE
Change markdown json rendering from json to jsonc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://marketplace.visualstudio.com/items?itemName=febean.vue-format
 - 使用[js-beautify](https://github.com/beautify-web/js-beautify)配置 和 [pug-beautify](https://github.com/vingorius/pug-beautify)配置
 - indent_size 默认使用 editor.tabSize
 
-```json
+```jsonc
 {
     "html_indent_root": false, // 是否缩进vue template中的根节点
     "break_attr_limit": -1, // tag 的 attrs 大于该数值时，强制 attrs 换行，-1时不换行

--- a/README_EN.md
+++ b/README_EN.md
@@ -26,7 +26,7 @@ https://marketplace.visualstudio.com/items?itemName=febean.vue-format
 - Use [js-beautify](https://github.com/beautify-web/js-beautify)'s config 和 [pug-beautify](https://github.com/vingorius/pug-beautify)'s config
 - indent_size: default use the "editor.tabSize"
 
-```json
+```jsonc
 {
     "html_indent_root": false, // If need to indent the root tag of template in ".vue" file
     "break_attr_limit": -1, // when attributes.length > the value，break attributes force; keep inline when -1.


### PR DESCRIPTION
Using JSONC (json with comments) to render json file instead of JSON so that we can render json file with comments properly.

Super easy change, but makes the user experience better.